### PR TITLE
Disable blur for apps in fullscreen

### DIFF
--- a/BlurFocus/BlurFocus.m
+++ b/BlurFocus/BlurFocus.m
@@ -51,7 +51,8 @@ static void     *isActive = &isActive;
 + (void)BF_blurWindow:(NSNotification *)note
 {
     NSWindow *win = note.object;
-    if (![objc_getAssociatedObject(win, isActive) boolValue]) {
+    if (![objc_getAssociatedObject(win, isActive) boolValue]
+            && !([win styleMask] & NSWindowStyleMaskFullScreen)) {
         NSArray *_defaultFilters = [[win.contentView superview] contentFilters];
         objc_setAssociatedObject(win, filterCache, _defaultFilters, OBJC_ASSOCIATION_RETAIN);
         [[win.contentView superview] setWantsLayer:YES];

--- a/BlurFocus/Info.plist
+++ b/BlurFocus/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.17</string>
+	<string>1.0.18</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.17</string>
+	<string>1.0.18</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2016 Wolfgang Baird. All rights reserved.</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Disable blur filter for apps in fullscreen to avoid the split-second delay for clearing the filter when switching between spaces.